### PR TITLE
Revert "Update match duration formatting"

### DIFF
--- a/Dota2WebApiMatchInfo.php
+++ b/Dota2WebApiMatchInfo.php
@@ -235,7 +235,7 @@ class Dota2WebApiMatchInfo {
 
 	private function getDuration() {
 		$duration = $this->_match_details->result->duration;
-		$this->_result->duration = sprintf('%02dm%02ds', $duration / 60, $duration % 60);
+		$this->_result->duration = sprintf('%02d:%02d', $duration / 60, $duration % 60);
 	}
 
 	private function getRadiantWin() {


### PR DESCRIPTION
Reverts Liquipedia/Dota2WebApi#2
Apparently this broke something since now it just doesn't display a time at all -_- 