### PR TITLE
Set match2 checkbox as checked by default

### DIFF
--- a/resources/scripts/ext.dota2WebApi.toolbar.js
+++ b/resources/scripts/ext.dota2WebApi.toolbar.js
@@ -41,7 +41,7 @@ $( function() {
 			);
 		}
 		output += '</table><br>';
-		output += '<input type="checkbox" id="dota2db-dialog-match2-output" name="dota2db-dialog-match2-output">';
+		output += '<input type="checkbox" id="dota2db-dialog-match2-output" name="dota2db-dialog-match2-output" checked>';
 		output += '<label for="dota2db-dialog-match2-output">' + mw.message( 'dota2db-dialog-match2-output' ).text() + '</label><br>';
 
 		return output;


### PR DESCRIPTION
Dota2 is now live with match2. Have the match2 checkbox checked by default.

(Untested)